### PR TITLE
Supress warning on socket write

### DIFF
--- a/src/Statsd/Client/SocketConnection.php
+++ b/src/Statsd/Client/SocketConnection.php
@@ -56,6 +56,6 @@ class SocketConnection implements ConnectionInterface
 
     public function fwrite($socket, $string)
     {
-        return fwrite($socket, $string);
+        return @fwrite($socket, $string);
     }
 }


### PR DESCRIPTION
due to connection to udp socket opens, but later, during socket write, warning is generated when host is unreachable

http://php.net/manual/en/function.fsockopen.php
see Warning section for more information