### PR TITLE
Add telegraf tags

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "phpunit/phpunit": "3.7.*",
         "satooshi/php-coveralls": "dev-master"
     },
- 	"extra": {
+        "extra": {
         "branch-alias": {
             "dev-master": "0.8.1-dev"
         }

--- a/src/Statsd/Client.php
+++ b/src/Statsd/Client.php
@@ -1,9 +1,8 @@
 <?php
 namespace Statsd;
-          
+
 class Client
 {
-
     protected $commands = array();
 
     public function __construct(array $settings=array())
@@ -16,7 +15,7 @@ class Client
             ),
             $settings
         );
-        if($this->settings['connection'] == null){
+        if ($this->settings['connection'] == null) {
             $this->connection = new Client\SocketConnection($this->settings);
         } else {
             $this->connection = $this->settings['connection'];
@@ -33,7 +32,7 @@ class Client
            '\Statsd\Client\Command\Gauge',
         );
 
-        foreach($commands as $cmd) {
+        foreach ($commands as $cmd) {
             $this->addCommand(new $cmd);
         }
     }
@@ -45,7 +44,7 @@ class Client
             'Statsd\Client\CommandInterface',
             array_keys(class_implements($cmd_obj))
         );
-        if(!$instanceof) {
+        if (!$instanceof) {
             throw new \InvalidArgumentException(
                 sprintf(
                     "%s::addCommand() accept class that implements CommandInterface",
@@ -61,7 +60,7 @@ class Client
 
     public function __call($name, $arguments)
     {
-        if(!array_key_exists($name, $this->commands)) {
+        if (!array_key_exists($name, $this->commands) ) {
             throw new \BadFunctionCallException(
                 sprintf(
                     "Call to undefined method %s::%s()",
@@ -75,7 +74,7 @@ class Client
             if (!trim($command)) {
                 return $this;
             }
-            if(trim($this->getPrefix())){
+            if (trim($this->getPrefix())) {
                 $command = sprintf(
                     "%s.%s",
                     $this->getPrefix(),
@@ -83,8 +82,8 @@ class Client
                 );
             }
             $this->connection->send($command);
-        } catch(\Exception $e) {
-            if($this->settings['throw_exception'] == true) {
+        } catch (\Exception $e) {
+            if ($this->settings['throw_exception'] == true) {
                 throw $e;
             }
         }

--- a/src/Statsd/Client.php
+++ b/src/Statsd/Client.php
@@ -1,6 +1,8 @@
 <?php
 namespace Statsd;
 
+use \Statsd\Client\CommandInterface;
+
 class Client
 {
     protected $commands = array();
@@ -49,26 +51,12 @@ class Client
     }
 
     /**
-     * @param Statsd\Client\CommandInterface
+     * @param \Statsd\Client\CommandInterface
      */
-    public function addCommand($cmd_obj)
+    public function addCommand(CommandInterface $cmdObj)
     {
-        $class = new \ReflectionObject($cmd_obj);
-        $instanceof =  in_array(
-            'Statsd\Client\CommandInterface',
-            array_keys(class_implements($cmd_obj))
-        );
-        if (!$instanceof) {
-            throw new \InvalidArgumentException(
-                sprintf(
-                    "%s::addCommand() accept class that implements CommandInterface",
-                    __CLASS__
-                )
-            );
-        }
-
-        foreach($cmd_obj->getCommands() as $cmd){
-            $this->commands[$cmd] = $cmd_obj;
+        foreach ($cmdObj->getCommands() as $cmd) {
+            $this->commands[$cmd] = $cmdObj;
         }
     }
 
@@ -106,9 +94,9 @@ class Client
 
     protected function callCommand($name, $arguments)
     {
-        $cmd_obj = $this->commands[$name];
+        $cmdObj = $this->commands[$name];
         return call_user_func_array(
-            array($cmd_obj, $name),
+            array($cmdObj, $name),
             $arguments
         );
     }

--- a/src/Statsd/Client.php
+++ b/src/Statsd/Client.php
@@ -5,16 +5,27 @@ class Client
 {
     protected $commands = array();
 
+    /**
+     * Returns associative array of deafult settings.
+     *
+     * @return array
+     */
+    protected static function getDefaultSettings()
+    {
+        return array(
+                    'prefix' => '',
+                    'throw_exception' => false,
+                    'connection' => null
+                );
+    }
+
     public function __construct(array $settings=array())
     {
         $this->settings = array_merge(
-            array(
-                'prefix' => '',
-                'throw_exception' => false,
-                'connection' => null,
-            ),
+            static::getDefaultSettings(),
             $settings
         );
+
         if ($this->settings['connection'] == null) {
             $this->connection = new Client\SocketConnection($this->settings);
         } else {
@@ -23,7 +34,7 @@ class Client
         $this->registerCommands();
     }
 
-    private function registerCommands()
+    protected function registerCommands()
     {
         $commands = array(
            '\Statsd\Client\Command\Counter',
@@ -37,6 +48,9 @@ class Client
         }
     }
 
+    /**
+     * @param Statsd\Client\CommandInterface
+     */
     public function addCommand($cmd_obj)
     {
         $class = new \ReflectionObject($cmd_obj);
@@ -90,7 +104,7 @@ class Client
         return $this;
     }
 
-    private function callCommand($name, $arguments)
+    protected function callCommand($name, $arguments)
     {
         $cmd_obj = $this->commands[$name];
         return call_user_func_array(

--- a/src/Statsd/Client/Command.php
+++ b/src/Statsd/Client/Command.php
@@ -5,8 +5,8 @@ abstract class Command implements CommandInterface
 {
     protected function prepare($stat, $value, $rate=1)
     {
-        if($rate < 1 ) {
-            if($this->genRand() < $rate){
+        if ($rate < 1 ) {
+            if ($this->genRand() < $rate) {
                 $value = sprintf('%s|@%s', $value, $rate);
             } else {
                 return;
@@ -17,6 +17,6 @@ abstract class Command implements CommandInterface
 
     public function genRand()
     {
-        return (float)mt_rand()/(float)mt_getrandmax();
+        return (float) mt_rand() / (float) mt_getrandmax();
     }
 }

--- a/src/Statsd/Client/Command/Timer.php
+++ b/src/Statsd/Client/Command/Timer.php
@@ -17,7 +17,7 @@ class Timer extends \Statsd\Client\Command
 
     public function timing($stat, $delta, $rate=1)
     {
-        if($this->isClosure($delta)){
+        if ($this->isClosure($delta)) {
             $start_time = gettimeofday(true);
             $delta();
             $end_time = gettimeofday(true);

--- a/src/Statsd/Client/SocketConnection.php
+++ b/src/Statsd/Client/SocketConnection.php
@@ -19,7 +19,6 @@ class SocketConnection implements ConnectionInterface
     public function openSocket()
     {
         try {
-
             $this->socket = $this->fsockopen(
                 sprintf(
                     "udp://%s",
@@ -27,7 +26,7 @@ class SocketConnection implements ConnectionInterface
                 ),
                 $this->settings['port']
             );
-        } catch(\Exception $e) {
+        } catch (\Exception $e) {
             if($this->settings['throw_exception'] == true) {
                 throw $e;
             }
@@ -37,7 +36,7 @@ class SocketConnection implements ConnectionInterface
 
     private function fsockopen($host, $port)
     {
-        return fsockopen($host, $port); 
+        return fsockopen($host, $port);
     }
 
     public function send($string)
@@ -46,7 +45,7 @@ class SocketConnection implements ConnectionInterface
             if (trim($string)) {
                 return $this->fwrite($this->socket, $string);
             }
-        } catch(\Exception $e) {
+        } catch (\Exception $e) {
             if($this->settings['throw_exception'] == true) {
                 throw $e;
             }

--- a/src/Statsd/Telegraf/Client.php
+++ b/src/Statsd/Telegraf/Client.php
@@ -20,7 +20,35 @@ class Client extends \Statsd\Client
                     'prefix' => '',
                     'throw_exception' => false,
                     'connection' => null,
-                    'tags' => array()
+                    'default_tags' => array()
                 );
+    }
+
+    /**
+     * Return associative array of default tags applied for all metrics
+     * without specific tags.
+     *
+     * @return array
+     */
+    public function getDefaultTags()
+    {
+        return $this->settings['default_tags'];
+    }
+
+    protected function registerCommands()
+    {
+        $tags = $this->getDefaultTags();
+
+        $commands = array(
+           new Counter(),
+           new Set(),
+           new Timer(),
+           new Gauge(),
+        );
+
+        foreach ($commands as $command) {
+            $command->setDefaultTags($tags);
+            $this->addCommand($command);
+        }
     }
 }

--- a/src/Statsd/Telegraf/Client.php
+++ b/src/Statsd/Telegraf/Client.php
@@ -1,0 +1,26 @@
+<?php
+namespace Statsd\Telegraf;
+
+use Statsd\Telegraf\Client\Command\Counter;
+use Statsd\Telegraf\Client\Command\Set;
+use Statsd\Telegraf\Client\Command\Timer;
+use Statsd\Telegraf\Client\Command\Gauge;
+
+
+class Client extends \Statsd\Client
+{
+    /**
+     * Returns associative array of deafult settings.
+     *
+     * @return array
+     */
+    protected static function getDefaultSettings()
+    {
+        return array(
+                    'prefix' => '',
+                    'throw_exception' => false,
+                    'connection' => null,
+                    'tags' => array()
+                );
+    }
+}

--- a/src/Statsd/Telegraf/Client.php
+++ b/src/Statsd/Telegraf/Client.php
@@ -1,6 +1,7 @@
 <?php
 namespace Statsd\Telegraf;
 
+use BadMethodCallException;
 use Statsd\Telegraf\Client\Command\Counter;
 use Statsd\Telegraf\Client\Command\Set;
 use Statsd\Telegraf\Client\Command\Timer;
@@ -50,5 +51,19 @@ class Client extends \Statsd\Client
             $command->setDefaultTags($tags);
             $this->addCommand($command);
         }
+    }
+
+    public function __call($name, $args)
+    {
+        if (!array_key_exists($name, $this->commands) ) {
+            throw new BadMethodCallException(
+                sprintf(
+                    "Call to undefined method %s::%s()",
+                    get_class($this),
+                    $name
+                )
+            );
+        }
+        return parent::__call($name, $args);
     }
 }

--- a/src/Statsd/Telegraf/Client/Command/AbstractCommand.php
+++ b/src/Statsd/Telegraf/Client/Command/AbstractCommand.php
@@ -1,0 +1,79 @@
+<?php
+namespace Statsd\Telegraf\Client\Command;
+
+use Statsd\Client\CommandInterface;
+
+abstract class AbstractCommand implements CommandInterface
+{
+    /**
+     * @var array       associative array of tag name => value
+     */
+    protected $defaultTags = array();
+
+    /**
+     * @return array
+     */
+    abstract public function getCommands();
+
+    /**
+     * @param array       associative array of tag name => value
+     * @return \Statsd\Telegraf\Client\Command\AbstractCommand self reference
+     */
+    public function setDefaultTags(array $tags)
+    {
+        $this->defaultTags = $tags;
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getDefaultTags()
+    {
+        return $this->defaultTags;
+    }
+
+    /**
+     * @param string $stat
+     * @param int    $value
+     * @param float  $rate
+     * @param array  $tags      associative array of tag name => values
+     * @return string|null
+     */
+    protected function prepare($stat, $value, $rate, array $tags=array())
+    {
+        if ($rate < 1) {
+            if ($this->genRand() >= $rate) {
+                return null;
+            }
+            $value = sprintf('%s|@%s', $value, $rate);
+        }
+        return sprintf('%s:%s', $this->getStatWithTags($stat, $tags), $value);
+    }
+
+    /**
+     * @param string $stat
+     * @param array  $tags      associative array of tag name => values
+     * @return string
+     */
+    protected function getStatWithTags($stat, array $statTags=array())
+    {
+        $tags = $statTags ? $statTags : $this->getDefaultTags();
+        if (!$tags) {
+            return $stat;
+        }
+        $chunks = array($stat);
+        foreach ($tags as $key => $value) {
+            $chunks[] = sprintf("%s=%s", $key, $value);
+        }
+        return implode(',', $chunks);
+    }
+
+    /**
+     * @return float
+     */
+    protected function genRand()
+    {
+        return (float) mt_rand() / (float) mt_getrandmax();
+    }
+}

--- a/src/Statsd/Telegraf/Client/Command/Counter.php
+++ b/src/Statsd/Telegraf/Client/Command/Counter.php
@@ -1,0 +1,37 @@
+<?php
+namespace Statsd\Telegraf\Client\Command;
+
+
+class Counter extends AbstractCommand
+{
+    private $commands = array('incr', 'decr');
+
+    public function getCommands()
+    {
+        return $this->commands;
+    }
+
+    /**
+     * @param string $stat      metric name
+     * @param int    $count     counter
+     * @param float  $rate      sample rate
+     * @param array  $tags      associative array of tag name => values
+     * @return string|null
+     */
+    public function incr($stat, $count=1, $rate=1, array $tags=array())
+    {
+        return $this->prepare($stat, sprintf('%s|c', $count), $rate, $tags);
+    }
+
+    /**
+     * @param string $stat      metric name
+     * @param int    $count     counter
+     * @param float  $rate      sample rate
+     * @param array  $tags      associative array of tag name => values
+     * @return string|null
+     */
+    public function decr($stat, $count=1, $rate=1, array $tags=array())
+    {
+        return $this->incr($stat, -1 * $count, $rate, $tags);
+    }
+}

--- a/src/Statsd/Telegraf/Client/Command/Gauge.php
+++ b/src/Statsd/Telegraf/Client/Command/Gauge.php
@@ -1,0 +1,39 @@
+<?php
+namespace Statsd\Telegraf\Client\Command;
+
+
+class Gauge extends AbstractCommand
+{
+    private $commands = array('gauge');
+
+    /**
+     * @return array
+     */
+    public function getCommands()
+    {
+        return $this->commands;
+    }
+
+    /**
+     * @param string          $stat      metric name
+     * @param float|int       $value     gauge value
+     * @param float           $rate      sample rate
+     * @param bool            $delta     if the value is a delta
+     * @param array           $tags      associative array of tag name => values
+     * @return string|null
+     */
+    public function gauge($stat, $value, $rate=1, $delta=false, array $tags=array())
+    {
+        /**
+         * I prefer not to mix parameters, but really want to be API compatible
+         * with Statsd\Client\Command classes
+         */
+        if (is_bool($rate)) {
+            $delta = $rate;
+            $rate = 1;
+        }
+
+        $statValue = $delta ? sprintf('%+g|g', $value) : sprintf('%g|g', $value);
+        return $this->prepare($stat, $statValue, $rate, $tags);
+    }
+}

--- a/src/Statsd/Telegraf/Client/Command/Set.php
+++ b/src/Statsd/Telegraf/Client/Command/Set.php
@@ -1,0 +1,28 @@
+<?php
+namespace Statsd\Telegraf\Client\Command;
+
+
+class Set extends AbstractCommand
+{
+    private $commands = array('set');
+
+    /**
+     * @return array
+     */
+    public function getCommands()
+    {
+        return $this->commands;
+    }
+
+    /**
+     * @param string          $stat      metric name
+     * @param string          $value     value in the data set
+     * @param float           $rate      sample rate
+     * @param array           $tags      associative array of tag name => values
+     * @return string|null
+     */
+    public function set($stat, $value, $rate=1, array $tags=array())
+    {
+        return $this->prepare($stat, sprintf('%s|s', $value), $rate, $tags);
+    }
+}

--- a/src/Statsd/Telegraf/Client/Command/Timer.php
+++ b/src/Statsd/Telegraf/Client/Command/Timer.php
@@ -22,7 +22,7 @@ class Timer extends AbstractCommand
     {
         if ($this->isCallable($delta)) {
             $startTime = gettimeofday(true);
-            $delta();
+            call_user_func($delta);
             $endTime = gettimeofday(true);
             $delta = ($endTime - $startTime) * 1000;
         }

--- a/src/Statsd/Telegraf/Client/Command/Timer.php
+++ b/src/Statsd/Telegraf/Client/Command/Timer.php
@@ -1,0 +1,32 @@
+<?php
+namespace Statsd\Telegraf\Client\Command;
+
+
+class Timer extends AbstractCommand
+{
+    private $commands = array('timing');
+
+    public function getCommands()
+    {
+        return $this->commands;
+    }
+
+    /**
+     * @param string          $stat      metric name
+     * @param int|callable    $delta     time delta in miliseconds, or callable to call
+     * @param float           $rate      sample rate
+     * @param array           $tags      associative array of tag name => values
+     * @return string|null
+     */
+    public function timing($stat, $delta, $rate=1, array $tags=array())
+    {
+        if (is_callable($delta)) {
+            $startTime = gettimeofday(true);
+            $delta();
+            $endTime = gettimeofday(true);
+            $delta = ($endTime - $startTime) * 1000;
+        }
+
+        return $this->prepare($stat, sprintf('%d|ms', $delta), $rate, $tags);
+    }
+}

--- a/src/Statsd/Telegraf/Client/Command/Timer.php
+++ b/src/Statsd/Telegraf/Client/Command/Timer.php
@@ -20,7 +20,7 @@ class Timer extends AbstractCommand
      */
     public function timing($stat, $delta, $rate=1, array $tags=array())
     {
-        if (is_callable($delta)) {
+        if ($this->isCallable($delta)) {
             $startTime = gettimeofday(true);
             $delta();
             $endTime = gettimeofday(true);
@@ -28,5 +28,20 @@ class Timer extends AbstractCommand
         }
 
         return $this->prepare($stat, sprintf('%d|ms', $delta), $rate, $tags);
+    }
+
+    /**
+     * @param  mixed   $callable
+     * @return bool
+     */
+    private function isCallable($callable)
+    {
+        if (is_array($callable)) {
+            if (count($callable) !== 2) {
+                return false;
+            }
+            return method_exists($callable[0], $callable[1]);
+        }
+        return is_callable($callable);
     }
 }

--- a/t/Test/Statsd/Client/Command/CounterTest.php
+++ b/t/Test/Statsd/Client/Command/CounterTest.php
@@ -40,7 +40,6 @@ class CounterTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-
     public function testIncrSendByRate()
     {
         $inc = $this->getMock(
@@ -88,5 +87,4 @@ class CounterTest extends \PHPUnit_Framework_TestCase
             $inc->decr('foo.bar')
         );
     }
-
 }

--- a/t/Test/Statsd/Client/Command/TimerTest.php
+++ b/t/Test/Statsd/Client/Command/TimerTest.php
@@ -16,7 +16,7 @@ class TimerTest extends \PHPUnit_Framework_TestCase
     {
         $inc = new \Statsd\Client\Command\Timer();
         $class = new \ReflectionClass('\Statsd\Client\Command\Timer');
-        foreach($inc->getCommands() as $cmd){
+        foreach ($inc->getCommands() as $cmd) {
             $method = $class->getMethod($cmd);
         }
     }

--- a/t/Test/Statsd/Client/SocketConnectionTest.php
+++ b/t/Test/Statsd/Client/SocketConnectionTest.php
@@ -3,7 +3,6 @@ namespace Test\Statsd\Client;
 
 class SocketConnectionTest extends \PHPUnit_Framework_TestCase
 {
-
     public function testObject()
     {
         $sc = new \Statsd\Client\SocketConnection(
@@ -104,5 +103,4 @@ class SocketConnectionTest extends \PHPUnit_Framework_TestCase
             $sc->send("123456")
         );
     }
-
 }

--- a/t/Test/Statsd/Client/SocketConnectionTest.php
+++ b/t/Test/Statsd/Client/SocketConnectionTest.php
@@ -42,6 +42,10 @@ class SocketConnectionTest extends \PHPUnit_Framework_TestCase
      */
     public function testExceptioOpenSocket()
     {
+        $this->markTestSkipped(
+            "Throwing exceptions on socket connection is not consistent between HHVM and PHP"
+            . "Even PHP documentation says detecting connection errors is not gruaranteed for UDP sockets"
+        );
         $sc = $this->getMock(
             '\Statsd\Client\SocketConnection',
             array(

--- a/t/Test/Statsd/ClientTest.php
+++ b/t/Test/Statsd/ClientTest.php
@@ -69,7 +69,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
     public function testClientAddCommand()
     {
-        $sc = $this->getMockUpSocketConnection();    
+        $sc = $this->getMockUpSocketConnection();
         $sc->expects($this->once())
             ->method('send')
             ->with("foo.bar:1|c");
@@ -78,7 +78,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $statsd->addCommand(
             new \Statsd\Client\Command\Counter()
         );
-        
+
         $this->assertInstanceOf(
             '\Statsd\Client',
             $statsd->incr('foo.bar', 1)
@@ -87,7 +87,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
     public function testClientCallCommandWithPrefix()
     {
-        $sc = $this->getMockUpSocketConnection();    
+        $sc = $this->getMockUpSocketConnection();
         $sc->expects($this->once())
             ->method('send')
             ->with("top.foo.bar:1|c");
@@ -97,7 +97,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
             new \Statsd\Client\Command\Counter()
         );
         $statsd->setPrefix('top');
-        
+
         $this->assertInstanceOf(
             '\Statsd\Client',
             $statsd->incr('foo.bar', 1)
@@ -137,5 +137,4 @@ class ClientTest extends \PHPUnit_Framework_TestCase
             $result
         );
     }
-
 }

--- a/t/Test/Statsd/ClientTest.php
+++ b/t/Test/Statsd/ClientTest.php
@@ -41,16 +41,6 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $statsd->fooFunc("foo", "bar");
     }
 
-    /**
-     * @expectedException InvalidArgumentException 
-     * @expectedExceptionMessage Statsd\Client::addCommand() accept class that implements CommandInterface
-     */
-    public function testClientWithWrongCommandObject()
-    {
-        $statsd = new \Statsd\Client();
-        $statsd->addCommand(new \StdClass());
-    }
-
     public function getMockUpSocketConnection()
     {
         return $this->getMock(

--- a/t/Test/Statsd/Telegraf/Client/Command/CounterTest.php
+++ b/t/Test/Statsd/Telegraf/Client/Command/CounterTest.php
@@ -1,0 +1,170 @@
+<?php
+namespace Test\Statsd\Telegraf\Client\Command;
+
+use Statsd\Telegraf\Client\Command\Counter;
+
+
+class CounterTest extends \PHPUnit_Framework_TestCase
+{
+    public function testImplementsCommandInterface()
+    {
+        $impl = new Counter();
+        $this->assertInstanceOf('\\Statsd\\Client\\CommandInterface', $impl);
+    }
+
+    public function testDefaultTagsIsEmptyByDefault()
+    {
+        $impl = new Counter();
+        $this->assertEquals(
+            array(),
+            $impl->getDefaultTags()
+        );
+    }
+
+    public function testSetAndGetDefaultTags()
+    {
+        $tags = array('name1' => 'value1', 'name2' => 'value2');
+        $impl = new Counter();
+        $this->assertEquals(
+            $tags,
+            $impl->setDefaultTags($tags)->getDefaultTags()
+        );
+    }
+
+    public function testGetCommandsReturnsArrayOfMethodNames()
+    {
+        $impl = new Counter();
+        $commands = $impl->getCommands();
+        $this->assertInternalType('array', $commands);
+        $this->assertNotEmpty($commands);
+        foreach ($commands as $command)
+        {
+            $this->assertInternalType('callable', array($impl, $command));
+        }
+    }
+
+    /**
+     * @dataProvider provideParametersAndExpectedResultForIncr
+     */
+    public function testIncrCreatesProperOutputWhenSampleRateMatches($expected, $stat, $count, $rate, array $tags)
+    {
+        $impl = new Counter();
+        $this->assertEquals($expected, $impl->incr($stat, $count, $rate, $tags));
+    }
+
+    /**
+     * @return array
+     */
+    public static function provideParametersAndExpectedResultForIncr()
+    {
+        return array(
+            'count 1 no tags' => array('db.query:1|c', 'db.query', 1, 1, array()),
+            'count 2, 1 tag' => array('foo.bar,region=world:2|c', 'foo.bar', 2, 1, array('region' => 'world')),
+            'count 101, multiple tags' => array(
+                'long.metric.name,region=world,severity=low:101|c',
+                'long.metric.name',
+                101,
+                1,
+                array('region' => 'world', 'severity' => 'low')
+            ),
+        );
+    }
+
+    public function testIncrUsesDefaultTagsIfNoTagsIsSpecified()
+    {
+        $impl = new Counter();
+        $impl->setDefaultTags(array('tag1' => 'val1', 'tag2' => 'val2'));
+        $this->assertEquals('foo.bar,tag1=val1,tag2=val2:4|c', $impl->incr('foo.bar', 4, 1));
+    }
+
+    public function testIncrIncludesSampleRateInResult()
+    {
+        $implMock = $this->mockCounter(array('genRand'));
+        $implMock->expects($this->once())
+                ->method('genRand')
+                ->will($this->returnValue(0.45)
+        );
+
+        $this->assertEquals(
+            'foo.bar:1|c|@0.6',
+            $implMock->incr('foo.bar', 1, 0.6)
+        );
+    }
+
+    public function testIncrReturnsEmptyStringWhenSampleRateIsLow()
+    {
+        $implMock = $this->mockCounter(array('genRand'));
+        $implMock->expects($this->once())
+            ->method('genRand')
+            ->will($this->returnValue(0.85)
+        );
+        $this->assertNull($implMock->incr('foo.bar', 1 , 0.5));
+    }
+
+    /**
+     * @dataProvider provideParametersAndExpectedResultForDecr
+     */
+    public function testDecrCreatesProperOutputWhenSampleRateMatches($expected, $stat, $count, $rate, array $tags)
+    {
+        $impl = new Counter();
+        $this->assertEquals($expected, $impl->decr($stat, $count, $rate, $tags));
+    }
+
+    /**
+     * @return array
+     */
+    public static function provideParametersAndExpectedResultForDecr()
+    {
+        return array(
+            'count 1 no tags' => array('db.query:-1|c', 'db.query', 1, 1, array()),
+            'count 2, 1 tag' => array('foo.bar,region=world:-2|c', 'foo.bar', 2, 1, array('region' => 'world')),
+            'count 103, multiple tags' => array(
+                'long.metric.name,region=world,severity=low:-103|c',
+                'long.metric.name',
+                103,
+                1,
+                array('region' => 'world', 'severity' => 'low')
+            ),
+        );
+    }
+
+    public function testDecrUsesDefaultTagsIfNoTagsIsSpecified()
+    {
+        $impl = new Counter();
+        $impl->setDefaultTags(array('tag1' => 'val1', 'tag2' => 'val2'));
+        $this->assertEquals('foo.bar,tag1=val1,tag2=val2:-5|c', $impl->decr('foo.bar', 5, 1));
+    }
+
+    public function testDecrIncludesSampleRateInResult()
+    {
+        $implMock = $this->mockCounter(array('genRand'));
+        $implMock->expects($this->once())
+                ->method('genRand')
+                ->will($this->returnValue(0.45)
+        );
+
+        $this->assertEquals(
+            'foo.bar:-2|c|@0.6',
+            $implMock->decr('foo.bar', 2, 0.6)
+        );
+    }
+
+    public function testDecrReturnsEmptyStringWhenSampleRateIsLow()
+    {
+        $implMock = $this->mockCounter(array('genRand'));
+        $implMock->expects($this->once())
+            ->method('genRand')
+            ->will($this->returnValue(0.85)
+        );
+        $this->assertNull($implMock->decr('foo.bar', 2, 0.5));
+    }
+
+    private function mockCounter(array $methods=array())
+    {
+        $implMock = $this->getMock(
+            '\\Statsd\\Telegraf\\Client\\Command\\Counter',
+            $methods
+        );
+        return $implMock;
+    }
+}

--- a/t/Test/Statsd/Telegraf/Client/Command/CounterTest.php
+++ b/t/Test/Statsd/Telegraf/Client/Command/CounterTest.php
@@ -91,7 +91,7 @@ class CounterTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    public function testIncrReturnsEmptyStringWhenSampleRateIsLow()
+    public function testIncrReturnsNullWhenSampleRateIsLow()
     {
         $implMock = $this->mockCounter(array('genRand'));
         $implMock->expects($this->once())
@@ -149,7 +149,7 @@ class CounterTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    public function testDecrReturnsEmptyStringWhenSampleRateIsLow()
+    public function testDecrReturnsNullWhenSampleRateIsLow()
     {
         $implMock = $this->mockCounter(array('genRand'));
         $implMock->expects($this->once())

--- a/t/Test/Statsd/Telegraf/Client/Command/GaugeTest.php
+++ b/t/Test/Statsd/Telegraf/Client/Command/GaugeTest.php
@@ -1,0 +1,139 @@
+<?php
+namespace Test\Statsd\Telegraf\Client\Command;
+
+use Statsd\Telegraf\Client\Command\Gauge;
+
+
+class GaugeTest extends \PHPUnit_Framework_TestCase
+{
+    public function testImplementsCommandInterface()
+    {
+        $impl = new Gauge();
+        $this->assertInstanceOf('\\Statsd\\Client\\CommandInterface', $impl);
+    }
+
+    public function testDefaultTagsIsEmptyByDefault()
+    {
+        $impl = new Gauge();
+        $this->assertEquals(
+            array(),
+            $impl->getDefaultTags()
+        );
+    }
+
+    public function testGaugeAndGetDefaultTags()
+    {
+        $tags = array('name1' => 'value1', 'name2' => 'value2');
+        $impl = new Gauge();
+        $this->assertEquals(
+            $tags,
+            $impl->setDefaultTags($tags)->getDefaultTags()
+        );
+    }
+
+    public function testGetCommandsReturnsArrayOfMethodNames()
+    {
+        $impl = new Gauge();
+        $commands = $impl->getCommands();
+        $this->assertInternalType('array', $commands);
+        $this->assertNotEmpty($commands);
+        foreach ($commands as $command)
+        {
+            $this->assertInternalType('callable', array($impl, $command));
+        }
+    }
+
+    /**
+     * @dataProvider provideParametersAndExpectedResultForGauge
+     */
+    public function testGaugeCreatesProperOutputWhenSampleRateMatches($expected, $stat, $value, $rate, array $tags)
+    {
+        $impl = new Gauge();
+        $this->assertEquals($expected, $impl->gauge($stat, $value, $rate, false, $tags));
+    }
+
+    /**
+     * @return array
+     */
+    public static function provideParametersAndExpectedResultForGauge()
+    {
+        return array(
+            'gauge cpu_percent no tags' => array('cpu_percent:53|g', 'cpu_percent', 53, 1, array()),
+            'gauge mem_mb 1 tag' => array('mem_mb,region=world:132.5|g', 'mem_mb', 132.5, 1, array('region' => 'world')),
+            'gauge running_queries, multiple tags' => array(
+                'running_queries,region=world,severity=low:103|g',
+                'running_queries',
+                103,
+                1,
+                array('region' => 'world', 'severity' => 'low')
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider provideParametersAndExpectedResultForDeltaGauge
+     */
+    public function testGaugeCreatesProperOutputForDeltaGaugesWhenSampleRateMatches($expected, $stat, $value, $rate, array $tags)
+    {
+        $impl = new Gauge();
+        $this->assertEquals($expected, $impl->gauge($stat, $value, $rate, true, $tags));
+    }
+
+    /**
+     * @return array
+     */
+    public static function provideParametersAndExpectedResultForDeltaGauge()
+    {
+        return array(
+            'gauge cpu_percent no tags' => array('cpu_percent:+6|g', 'cpu_percent', 6, 1, array()),
+            'gauge mem_mb 1 tag' => array('mem_mb,region=world:+46.2|g', 'mem_mb', 46.2, 1, array('region' => 'world')),
+            'gauge running_queries, multiple tags' => array(
+                'running_queries,region=world,severity=low:-18|g',
+                'running_queries',
+                -18,
+                1,
+                array('region' => 'world', 'severity' => 'low')
+            ),
+        );
+    }
+
+    public function testGaugeUsesDefaultTagsIfNoTagsIsSpecified()
+    {
+        $impl = new Gauge();
+        $impl->setDefaultTags(array('tag1' => 'val1', 'tag2' => 'val2'));
+        $this->assertEquals('foo.bar,tag1=val1,tag2=val2:1000|g', $impl->gauge('foo.bar', 1000, 1));
+    }
+
+    public function testGaugeIncludesSampleRateInResult()
+    {
+        $implMock = $this->mockGauge(array('genRand'));
+        $implMock->expects($this->once())
+                ->method('genRand')
+                ->will($this->returnValue(0.45)
+        );
+
+        $this->assertEquals(
+            'foo.bar:20|g|@0.6',
+            $implMock->gauge('foo.bar', 20, 0.6)
+        );
+    }
+
+    public function testGaugeReturnsNullWhenSampleRateIsLow()
+    {
+        $implMock = $this->mockGauge(array('genRand'));
+        $implMock->expects($this->once())
+            ->method('genRand')
+            ->will($this->returnValue(0.85)
+        );
+        $this->assertNull($implMock->gauge('foo.bar', 30, 0.5));
+    }
+
+    private function mockGauge(array $methods=array())
+    {
+        $implMock = $this->getMock(
+            '\\Statsd\\Telegraf\\Client\\Command\\Gauge',
+            $methods
+        );
+        return $implMock;
+    }
+}

--- a/t/Test/Statsd/Telegraf/Client/Command/SetTest.php
+++ b/t/Test/Statsd/Telegraf/Client/Command/SetTest.php
@@ -1,0 +1,112 @@
+<?php
+namespace Test\Statsd\Telegraf\Client\Command;
+
+use Statsd\Telegraf\Client\Command\Set;
+
+
+class SetTest extends \PHPUnit_Framework_TestCase
+{
+    public function testImplementsCommandInterface()
+    {
+        $impl = new Set();
+        $this->assertInstanceOf('\\Statsd\\Client\\CommandInterface', $impl);
+    }
+
+    public function testDefaultTagsIsEmptyByDefault()
+    {
+        $impl = new Set();
+        $this->assertEquals(
+            array(),
+            $impl->getDefaultTags()
+        );
+    }
+
+    public function testSetAndGetDefaultTags()
+    {
+        $tags = array('name1' => 'value1', 'name2' => 'value2');
+        $impl = new Set();
+        $this->assertEquals(
+            $tags,
+            $impl->setDefaultTags($tags)->getDefaultTags()
+        );
+    }
+
+    public function testGetCommandsReturnsArrayOfMethodNames()
+    {
+        $impl = new Set();
+        $commands = $impl->getCommands();
+        $this->assertInternalType('array', $commands);
+        $this->assertNotEmpty($commands);
+        foreach ($commands as $command)
+        {
+            $this->assertInternalType('callable', array($impl, $command));
+        }
+    }
+
+    /**
+     * @dataProvider provideParametersAndExpectedResultForSet
+     */
+    public function testSetCreatesProperOutputWhenSampleRateMatches($expected, $stat, $value, $rate, array $tags)
+    {
+        $impl = new Set();
+        $this->assertEquals($expected, $impl->set($stat, $value, $rate, $tags));
+    }
+
+    /**
+     * @return array
+     */
+    public static function provideParametersAndExpectedResultForSet()
+    {
+        return array(
+            'set ip no tags' => array('user.ip:127.0.0.1|s', 'user.ip', '127.0.0.1', 1, array()),
+            'set username, 1 tag' => array('username,region=world:tester|s', 'username', 'tester', 1, array('region' => 'world')),
+            'set instances, multiple tags' => array(
+                'instance,region=world,severity=low:specific|s',
+                'instance',
+                'specific',
+                1,
+                array('region' => 'world', 'severity' => 'low')
+            ),
+        );
+    }
+
+    public function testSetUsesDefaultTagsIfNoTagsIsSpecified()
+    {
+        $impl = new Set();
+        $impl->setDefaultTags(array('tag1' => 'val1', 'tag2' => 'val2'));
+        $this->assertEquals('foo.bar,tag1=val1,tag2=val2:unique|s', $impl->set('foo.bar', 'unique', 1));
+    }
+
+    public function testSetIncludesSampleRateInResult()
+    {
+        $implMock = $this->mockSet(array('genRand'));
+        $implMock->expects($this->once())
+                ->method('genRand')
+                ->will($this->returnValue(0.45)
+        );
+
+        $this->assertEquals(
+            'foo.bar:unique|s|@0.6',
+            $implMock->set('foo.bar', 'unique', 0.6)
+        );
+    }
+
+    public function testSetReturnsNullWhenSampleRateIsLow()
+    {
+        $implMock = $this->mockSet(array('genRand'));
+        $implMock->expects($this->once())
+            ->method('genRand')
+            ->will($this->returnValue(0.85)
+        );
+        $this->assertNull($implMock->set('foo.bar', 'unique', 0.5));
+    }
+
+    private function mockSet(array $methods=array())
+    {
+        $implMock = $this->getMock(
+            '\\Statsd\\Telegraf\\Client\\Command\\Set',
+            $methods
+        );
+        return $implMock;
+    }
+}

--- a/t/Test/Statsd/Telegraf/Client/Command/TimerTest.php
+++ b/t/Test/Statsd/Telegraf/Client/Command/TimerTest.php
@@ -98,7 +98,7 @@ class TimerTest extends \PHPUnit_Framework_TestCase
             'test.static.method.sleep:1000|ms',
             $impl->timing(
                 'test.static.method.sleep',
-                '\\Test\\Statsd\\Telegraf\\Client\\Command\\TimerTest::staticallySleep1Second',
+                array('\\Test\\Statsd\\Telegraf\\Client\\Command\\TimerTest', 'staticallySleep1Second'),
                 1
             )
         );

--- a/t/Test/Statsd/Telegraf/Client/Command/TimerTest.php
+++ b/t/Test/Statsd/Telegraf/Client/Command/TimerTest.php
@@ -80,42 +80,42 @@ class TimerTest extends \PHPUnit_Framework_TestCase
     public function testTimingAcceptsAnObjectMethodToCallAndTimeTheExecution()
     {
         $impl = new Timer();
-        $this->assertEquals(
-            'test.method.sleep:1000|ms',
-            $impl->timing('test.method.sleep', array($this, 'sleep1Second'), 1)
+        $this->assertRegExp(
+            '/test.method.sleep:\d+\|ms/',
+            $impl->timing('test.method.sleep', array($this, 'sleepABit'), 1)
         );
     }
 
-    public function sleep1Second()
+    public function sleepABit()
     {
-        sleep(1);
+        usleep(300000);
     }
 
     public function testTimingAcceptsAClassStaticMethodToCallAndTimeTheExecution()
     {
         $impl = new Timer();
-        $this->assertEquals(
-            'test.static.method.sleep:1000|ms',
+        $this->assertRegExp(
+            '/test.static.method.sleep:\d+\|ms/',
             $impl->timing(
                 'test.static.method.sleep',
-                array('\\Test\\Statsd\\Telegraf\\Client\\Command\\TimerTest', 'staticallySleep1Second'),
+                array('\\Test\\Statsd\\Telegraf\\Client\\Command\\TimerTest', 'staticallySleepABit'),
                 1
             )
         );
     }
 
-    public static function staticallySleep1Second()
+    public static function staticallySleepABit()
     {
-        sleep(1);
+        usleep(300000);
     }
 
     public function testTimingAcceptsAClosureToCallAndTimeTheExecution()
     {
-        $sleep1Sec = function () { sleep(1); };
+        $sleepABit = function () { usleep(300000); };
         $impl = new Timer();
-        $this->assertEquals(
-            'test.closure.sleep:1000|ms',
-            $impl->timing('test.closure.sleep', $sleep1Sec, 1)
+        $this->assertRegExp(
+            '/test.closure.sleep:\d+\|ms/',
+            $impl->timing('test.closure.sleep', $sleepABit, 1)
         );
     }
 

--- a/t/Test/Statsd/Telegraf/Client/Command/TimerTest.php
+++ b/t/Test/Statsd/Telegraf/Client/Command/TimerTest.php
@@ -1,0 +1,154 @@
+<?php
+namespace Test\Statsd\Telegraf\Client\Command;
+
+use Statsd\Telegraf\Client\Command\Timer;
+
+
+class TimerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testImplementsCommandInterface()
+    {
+        $impl = new Timer();
+        $this->assertInstanceOf('\\Statsd\\Client\\CommandInterface', $impl);
+    }
+
+    public function testDefaultTagsIsEmptyByDefault()
+    {
+        $impl = new Timer();
+        $this->assertEquals(
+            array(),
+            $impl->getDefaultTags()
+        );
+    }
+
+    public function testSetAndGetDefaultTags()
+    {
+        $tags = array('name1' => 'value1', 'name2' => 'value2');
+        $impl = new Timer();
+        $this->assertEquals(
+            $tags,
+            $impl->setDefaultTags($tags)->getDefaultTags()
+        );
+    }
+
+    public function testGetCommandsReturnsArrayOfMethodNames()
+    {
+        $impl = new Timer();
+        $commands = $impl->getCommands();
+        $this->assertInternalType('array', $commands);
+        $this->assertNotEmpty($commands);
+        foreach ($commands as $command)
+        {
+            $this->assertInternalType('callable', array($impl, $command));
+        }
+    }
+
+    /**
+     * @dataProvider provideParametersAndExpectedResultForTiming
+     */
+    public function testTimingCreatesProperOutputWhenSampleRateMatches($expected, $stat, $delta, $rate, array $tags)
+    {
+        $impl = new Timer();
+        $this->assertEquals($expected, $impl->timing($stat, $delta, $rate, $tags));
+    }
+
+    /**
+     * @return array
+     */
+    public static function provideParametersAndExpectedResultForTiming()
+    {
+        return array(
+            'delta 1 no tags' => array('db.query:1|ms', 'db.query', 1, 1, array()),
+            'detla 10, 1 tag' => array('foo.bar,region=world:10|ms', 'foo.bar', 10, 1, array('region' => 'world')),
+            'count 101, multiple tags' => array(
+                'long.metric.name,region=world,severity=low:101|ms',
+                'long.metric.name',
+                101,
+                1,
+                array('region' => 'world', 'severity' => 'low')
+            ),
+        );
+    }
+
+    public function testTimingUsesDefaultTagsIfNoTagsIsSpecified()
+    {
+        $impl = new Timer();
+        $impl->setDefaultTags(array('tag1' => 'val1', 'tag2' => 'val2'));
+        $this->assertEquals('foo.bar,tag1=val1,tag2=val2:3|ms', $impl->timing('foo.bar', 3, 1));
+    }
+
+    public function testTimingAcceptsAnObjectMethodToCallAndTimeTheExecution()
+    {
+        $impl = new Timer();
+        $this->assertEquals(
+            'test.method.sleep:1000|ms',
+            $impl->timing('test.method.sleep', array($this, 'sleep1Second'), 1)
+        );
+    }
+
+    public function sleep1Second()
+    {
+        sleep(1);
+    }
+
+    public function testTimingAcceptsAClassStaticMethodToCallAndTimeTheExecution()
+    {
+        $impl = new Timer();
+        $this->assertEquals(
+            'test.static.method.sleep:1000|ms',
+            $impl->timing(
+                'test.static.method.sleep',
+                '\\Test\\Statsd\\Telegraf\\Client\\Command\\TimerTest::staticallySleep1Second',
+                1
+            )
+        );
+    }
+
+    public static function staticallySleep1Second()
+    {
+        sleep(1);
+    }
+
+    public function testTimingAcceptsAClosureToCallAndTimeTheExecution()
+    {
+        $sleep1Sec = function () { sleep(1); };
+        $impl = new Timer();
+        $this->assertEquals(
+            'test.closure.sleep:1000|ms',
+            $impl->timing('test.closure.sleep', $sleep1Sec, 1)
+        );
+    }
+
+    public function testTimingIncludesSampleRateInResult()
+    {
+        $implMock = $this->mockTimer(array('genRand'));
+        $implMock->expects($this->once())
+                ->method('genRand')
+                ->will($this->returnValue(0.45)
+        );
+
+        $this->assertEquals(
+            'foo.bar:1|ms|@0.6',
+            $implMock->timing('foo.bar', 1, 0.6)
+        );
+    }
+
+    public function testTimingReturnsNullWhenSampleRateIsLow()
+    {
+        $implMock = $this->mockTimer(array('genRand'));
+        $implMock->expects($this->once())
+            ->method('genRand')
+            ->will($this->returnValue(0.85)
+        );
+        $this->assertNull($implMock->timing('foo.bar', 1 , 0.5));
+    }
+
+    private function mockTimer(array $methods=array())
+    {
+        $implMock = $this->getMock(
+            '\\Statsd\\Telegraf\\Client\\Command\\Timer',
+            $methods
+        );
+        return $implMock;
+    }
+}

--- a/t/Test/Statsd/Telegraf/ClientTest.php
+++ b/t/Test/Statsd/Telegraf/ClientTest.php
@@ -1,0 +1,60 @@
+<?php
+namespace Test\Statsd\Telegraf;
+
+use StdClass;
+use Statsd\Telegraf\Client;
+use Statsd\Telegraf\Client\Command\Counter;
+use Statsd\Telegraf\Client\Command\Timer;
+
+class ClientTest extends \PHPUnit_Framework_TestCase
+{
+    public function testClientDefaultSettings()
+    {
+        $client = new Client();
+        $this->assertEquals('', $client->getPrefix());
+
+        $allSettings = $client->getSettings();
+        $this->assertFalse($allSettings['throw_exception']);
+        $this->assertEquals(array(), $allSettings['tags']);
+    }
+
+    /**
+     * @dataProvider provideExpectedSettingsAndConstructorParams
+     */
+    public function testClientSettingsOverrideDefaults(
+        array $expectedSettings,
+        array $constructorSettings
+    )
+    {
+        $client = new Client($constructorSettings);
+        $this->assertEquals($expectedSettings, $client->getSettings());
+    }
+
+    /**
+     * @return array
+     */
+    public static function provideExpectedSettingsAndConstructorParams()
+    {
+        $defaultSettings = array(
+            'throw_exception' => false,
+            'tags' => array(),
+            'connection' => null,
+            'prefix' => ''
+        );
+
+        $prefixSettings = $defaultSettings;
+        $prefixSettings['prefix'] = 'test';
+        $prefixParams = array('prefix' => 'test');
+
+        $tagsAndExceptionsSettings = $defaultSettings;
+        $tagsAndExceptionsSettings['tags'] = array('region' => 'world');
+        $tagsAndExceptionsSettings['throw_exception'] = true;
+        $tagsAndExceptionsParams = array('tags' => array('region' => 'world'), 'throw_exception' => true);
+
+        return array(
+            'empty params' => array($defaultSettings, array()),
+            'prefix params' => array($prefixSettings, $prefixParams),
+            'tags and throw_exception params' => array($tagsAndExceptionsSettings, $tagsAndExceptionsParams),
+        );
+    }
+}

--- a/t/Test/Statsd/Telegraf/ClientTest.php
+++ b/t/Test/Statsd/Telegraf/ClientTest.php
@@ -57,4 +57,14 @@ class ClientTest extends \PHPUnit_Framework_TestCase
             'tags and throw_exception params' => array($tagsAndExceptionsSettings, $tagsAndExceptionsParams),
         );
     }
+
+    /**
+     * @expectedException BadMethodCallException
+     * @expectedExceptionMessage Call to undefined method Statsd\Telegraf\Client::fooFunc()
+     */
+    public function testClientWithWrongCommand()
+    {
+        $client = new Client();
+        $client->fooFunc("foo", "bar");
+    }
 }

--- a/t/Test/Statsd/Telegraf/ClientTest.php
+++ b/t/Test/Statsd/Telegraf/ClientTest.php
@@ -121,6 +121,156 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    /**
+     * @dataProvider provideParamsForIncrAndExpectedRequest
+     */
+    public function testClientSupportsIncrByDefault(
+        $expectedRequest,
+        array $defaultTags,
+        $stat,
+        $count,
+        array $tags
+    )
+    {
+        $socketMock = $this->mockSocketConnection();
+        $socketMock->expects($this->once())->method('send')->with($expectedRequest);
+
+        $client = new Client(array('connection' => $socketMock, 'default_tags' => $defaultTags));
+        $this->assertInstanceOf(
+            '\\Statsd\\Telegraf\\Client',
+            $client->incr($stat, $count, 1, $tags)
+        );
+    }
+
+    public static function provideParamsForIncrAndExpectedRequest()
+    {
+        return array(
+            'no tags' => array('event.login:1|c', array(), 'event.login', 1, array()),
+            'with default tags' => array('event.good,region=world:3|c', array('region'=>'world'), 'event.good', 3, array()),
+            'with tags' => array('event.good,region=world:2|c', array(), 'event.good', 2, array('region' => 'world'))
+        );
+    }
+
+    /**
+     * @dataProvider provideParamsForDecrAndExpectedRequest
+     */
+    public function testClientSupportsDecrByDefault(
+        $expectedRequest,
+        array $defaultTags,
+        $stat,
+        $count,
+        array $tags
+    )
+    {
+        $socketMock = $this->mockSocketConnection();
+        $socketMock->expects($this->once())->method('send')->with($expectedRequest);
+
+        $client = new Client(array('connection' => $socketMock, 'default_tags' => $defaultTags));
+        $this->assertInstanceOf(
+            '\\Statsd\\Telegraf\\Client',
+            $client->decr($stat, $count, 1, $tags)
+        );
+    }
+
+    public static function provideParamsForDecrAndExpectedRequest()
+    {
+        return array(
+            'no tags' => array('event:-1|c', array(), 'event', 1, array()),
+            'with default tags' => array('event.bad,region=world:-2|c', array('region' => 'world'), 'event.bad', 2, array()),
+            'with tags' => array('event.bad,region=world:-3|c', array(), 'event.bad', 3, array('region' => 'world'))
+        );
+    }
+
+    /**
+     * @dataProvider provideParamsForTimingAndExpectedRequest
+     */
+    public function testClientSupportsTimingByDefault(
+        $expectedRequest,
+        array $defaultTags,
+        $stat,
+        $delta,
+        array $tags
+    )
+    {
+        $socketMock = $this->mockSocketConnection();
+        $socketMock->expects($this->once())->method('send')->with($expectedRequest);
+
+        $client = new Client(array('connection' => $socketMock, 'default_tags' => $defaultTags));
+        $this->assertInstanceOf(
+            '\\Statsd\\Telegraf\\Client',
+            $client->timing($stat, $delta, 1, $tags)
+        );
+    }
+
+    public static function provideParamsForTimingAndExpectedRequest()
+    {
+        return array(
+            'no tags' => array('query:1|ms', array(), 'query', 1, array()),
+            'with default tags' => array('db.query,region=world:2|ms', array('region' => 'world'), 'db.query', 2, array()),
+            'with tags' => array('db.query,region=world:34|ms', array(), 'db.query', 34, array('region' => 'world'))
+        );
+    }
+
+    /**
+     * @dataProvider provideParamsForSetAndExpectedRequest
+     */
+    public function testClientSupportsSetByDefault(
+        $expectedRequest,
+        array $defaultTags,
+        $stat,
+        $value,
+        array $tags
+    )
+    {
+        $socketMock = $this->mockSocketConnection();
+        $socketMock->expects($this->once())->method('send')->with($expectedRequest);
+
+        $client = new Client(array('connection' => $socketMock, 'default_tags' => $defaultTags));
+        $this->assertInstanceOf(
+            '\\Statsd\\Telegraf\\Client',
+            $client->set($stat, $value, 1, $tags)
+        );
+    }
+
+    public static function provideParamsForSetAndExpectedRequest()
+    {
+        return array(
+            'no tags' => array('id:1000|s', array(), 'id', 1000, array()),
+            'with default tags' => array('usr.id,region=world:2200|s', array('region' => 'world'), 'usr.id', 2200, array()),
+            'with tags' => array('usr.id,region=world:3|s', array(), 'usr.id', 3, array('region' => 'world'))
+        );
+    }
+
+    /**
+     * @dataProvider provideParamsForGaugeAndExpectedRequest
+     */
+    public function testClientSupportsGaugeByDefault(
+        $expectedRequest,
+        array $defaultTags,
+        $stat,
+        $value,
+        array $tags
+    )
+    {
+        $socketMock = $this->mockSocketConnection();
+        $socketMock->expects($this->once())->method('send')->with($expectedRequest);
+
+        $client = new Client(array('connection' => $socketMock, 'default_tags' => $defaultTags));
+        $this->assertInstanceOf(
+            '\\Statsd\\Telegraf\\Client',
+            $client->gauge($stat, $value, 1, false, $tags)
+        );
+    }
+
+    public static function provideParamsForGaugeAndExpectedRequest()
+    {
+        return array(
+            'no tags' => array('cpu_percent:44|g', array(), 'cpu_percent', 44, array()),
+            'with default tags' => array('resource.mem_mb,region=world:123|g', array('region' => 'world'), 'resource.mem_mb', 123, array()),
+            'with tags' => array('mem_mb,region=world:34|g', array(), 'mem_mb', 34, array('region' => 'world'))
+        );
+    }
+
     public function testClientSupportsFluentApi_WithAllStandardCommands()
     {
         $socketMock = $this->mockSocketConnection();

--- a/t/Test/Statsd/Telegraf/ClientTest.php
+++ b/t/Test/Statsd/Telegraf/ClientTest.php
@@ -15,7 +15,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
         $allSettings = $client->getSettings();
         $this->assertFalse($allSettings['throw_exception']);
-        $this->assertEquals(array(), $allSettings['tags']);
+        $this->assertEquals(array(), $allSettings['default_tags']);
     }
 
     /**
@@ -37,7 +37,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     {
         $defaultSettings = array(
             'throw_exception' => false,
-            'tags' => array(),
+            'default_tags' => array(),
             'connection' => null,
             'prefix' => ''
         );
@@ -47,9 +47,9 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $prefixParams = array('prefix' => 'test');
 
         $tagsAndExceptionsSettings = $defaultSettings;
-        $tagsAndExceptionsSettings['tags'] = array('region' => 'world');
+        $tagsAndExceptionsSettings['default_tags'] = array('region' => 'world');
         $tagsAndExceptionsSettings['throw_exception'] = true;
-        $tagsAndExceptionsParams = array('tags' => array('region' => 'world'), 'throw_exception' => true);
+        $tagsAndExceptionsParams = array('default_tags' => array('region' => 'world'), 'throw_exception' => true);
 
         return array(
             'empty params' => array($defaultSettings, array()),


### PR DESCRIPTION
Add a client (extending the default client) that accepts tags for metrics, and creates requests conforming to Telegraf extension of Statsd protocol.